### PR TITLE
apply to all ft=perl buffers, not only filename matches

### DIFF
--- a/plugin/trackperlvars.vim
+++ b/plugin/trackperlvars.vim
@@ -22,7 +22,10 @@ au FileType * call TPV__maybe_enable()
 
 function! TPV__maybe_enable ()
   if &filetype != 'perl'
-    return
+      augroup TrackVar
+          autocmd!
+      augroup END
+      return
   endif
 
   augroup TrackVar


### PR DESCRIPTION
fixes #2

This patch will set up a FileType event to set up buffer-local autocommands.  This means that the variable tracking should work in all perl-type buffers, not just ones with the filenames you had listed.  (I've tested this, but not tortured it.)
