### PR TITLE
clear the echomsg if not tracking var

### DIFF
--- a/plugin/trackperlvars.vim
+++ b/plugin/trackperlvars.vim
@@ -221,6 +221,8 @@ function! TPV_track_perl_var ()
         return
     else
         highlight! link TRACK_PERL_VAR_ACTIVE  TRACK_PERL_VAR
+        " Remove previous echomsg so that a definition isn't showing
+        echomsg ''
     endif
 
     " Remove previous highlighting...


### PR DESCRIPTION
If you highlight a var, then move off of it then the message is still pinned to the previous variable.

Another option that I was considering was to test if there was a message before setting echomsg.  It might just be the way I've setup my .vimrc conf, but the echomsg is being shown to me all the time.  Anyway line 278 doesn't seem entirely needed since it will echo the same message with out the '<none>' 7 lines later.
