### PR TITLE
change executable path name

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -783,7 +783,7 @@ endfunction
 
 augroup Perl_Setup
     autocmd!
-    autocmd BufNewFile   *  0r !vim_file_template <afile>
+    autocmd BufNewFile   *  0r !file_template <afile>
     autocmd BufNewFile   *  :call search('^[ \t]*[#].*implementation[ \t]\+here')
 augroup END
 


### PR DESCRIPTION
executable in bin/ has a different name to that in .vimrc file. "vim_file_template" vs "file_template"

also "Nmap" with upper case cause errors on my system (Ubuntu) changed locally to "nmap".