### PR TITLE
fix catch not catching anything

### DIFF
--- a/plugin/trackperlvars.vim
+++ b/plugin/trackperlvars.vim
@@ -389,7 +389,10 @@ function! TPV_track_perl_var ()
     endif
 
     " Remove previous highlighting...
-    try | call matchdelete(s:match_id) | catch /./ | endtry
+    try
+        call matchdelete(s:match_id)
+    catch /./
+    endtry
 
     " Locate a var under cursor...
     let cursline = getline('.')


### PR DESCRIPTION
The catch in this line stopped catching things, and this will always generate errors in a new buffer, making life painful. I'm not completely sure why this stopped working, but I think the `|` is meant more for interactive stuff then on-disk vimscript stuff anyway.